### PR TITLE
Normalize paths coming from PYTHONPATH

### DIFF
--- a/python/cohorte/boot/boot.py
+++ b/python/cohorte/boot/boot.py
@@ -38,7 +38,8 @@ import traceback
 try:
     for path in os.environ['PYTHONPATH'].split(os.pathsep):
         try:
-            sys.path.remove(path)
+            p = os.path.normpath(path)
+            sys.path.remove(p)
         except IndexError:
             pass
 


### PR DESCRIPTION
Normalize paths coming from `PYTHONPATH` before looking them up in `sys.path`.

Fixes isandlaTech/cohorte-runtime#33.